### PR TITLE
feat: add execute_cmd keymap for normal mode

### DIFF
--- a/lua/cmdpalette/init.lua
+++ b/lua/cmdpalette/init.lua
@@ -106,6 +106,7 @@ local function buf_keymap()
   vim.api.nvim_buf_set_keymap(buf, "n", "<C-d>", "<Cmd>lua require'cmdpalette'.clear_history()<CR>", opts)
   if type == "cmd" then
     vim.api.nvim_buf_set_keymap(buf, "i", "<CR>", "<Esc><Cmd>lua require'cmdpalette'.execute_cmd()<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buf, "n", "<CR>", "<Cmd>lua require'cmdpalette'.execute_cmd()<CR>", opts)
   end
 end
 


### PR DESCRIPTION
`<CR>` not executing in normal mode feels unintuitive in my opinion. This does change the current behavior so I could put it behind an option if necessary. I doubt anyone relies on `<CR>` moving down a line though.